### PR TITLE
Update ruby version to 2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     working_directory: ~/hopper
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: circleci/ruby:2.7.0
 
     steps:
       - checkout

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - node_modules/**/*
     - output/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.3.6
+  TargetRubyVersion: 2.7.0
   RSpec:
     Patterns:
       - _spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '2.6.5'
+ruby '2.7.0'
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ DEPENDENCIES
   token_validator!
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.7.0p0
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -30,6 +30,33 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Ruby
+
+This application requires:
+
+*   Ruby version: 2.7.0
+
+If you do not have Ruby installed, it is recommended you use ruby-install and chruby to manage Ruby versions.
+
+```bash
+brew install ruby-install chruby
+ruby-install ruby 2.7.0
+```
+
+Add the following lines to ~/.bash_profile:
+
+```bash
+source /usr/local/opt/chruby/share/chruby/chruby.sh
+source /usr/local/opt/chruby/share/chruby/auto.sh
+```
+
+Set Ruby version to 2.7.0:
+
+```bash
+source ~/.bash_profile
+chruby 2.7.0
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/hopper.

--- a/lib/hopper/version.rb
+++ b/lib/hopper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hopper
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/7793

*Why?*

Keeping our codebase up to date is part of the culture here at Ario.

*How?*

Update from 2.6.3 to 2.7.0 via `bundle update --ruby`

*How did this defect occur?*

N/A

*Risks*

Low.

*Requested Reviewers*

@gregfletch @deankeo 
