### PR TITLE
Allow servers to start on Hopper error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,6 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Max: 10
+
+RSpec/NestedGroups:
+  Max: 4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    hopper (0.2.0)
+    hopper (0.3.1)
       bunny (>= 2.13.0)
       rails
       rest-client

--- a/lib/hopper/version.rb
+++ b/lib/hopper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hopper
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,4 +36,10 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  logger = Logger.new($stdout)
+  config.before do
+    logger = Logger.new($stdout)
+    allow(Rails).to receive(:logger).and_return(logger)
+  end
 end


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

na

*Why?*

Servers will not start in case of a rabbitmq outage

*How?*

Raise error on init and retry publishing in case of failure

*How did this defect occur?*

NAD

*Risks*

Impacts the server init

*Requested Reviewers*

