### PR TITLE
Update rubocop config to remove warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,3 +47,18 @@ RSpec/ExampleLength:
 
 RSpec/NestedGroups:
   Max: 4
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true

--- a/lib/hopper.rb
+++ b/lib/hopper.rb
@@ -8,7 +8,9 @@ require 'bunny'
 
 # rubocop:disable Metrics/ModuleLength
 module Hopper
+  # rubocop:disable Lint/StructNewOverride
   RegistrationStruct = Struct.new(:subscriber, :method, :routing_key, :opts)
+  # rubocop:enable Lint/StructNewOverride
 
   class HopperError < StandardError; end
 


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/9255

*Why?*

Rubocop was updated and added new cops and was printing warning messages to enable/disable the new cops.

*How?*

Enable the new cops to make the warnings go away.

*How did this defect occur?*

N/A

*Risks*

Low

*Requested Reviewers*

@bcarr092 @dragoszt 
