### PR TITLE
feat: Add configuration for verify_peer.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    hopper (0.3.2)
+    hopper (0.4.0)
       bunny (>= 2.13.0)
       rails
       rest-client

--- a/lib/hopper.rb
+++ b/lib/hopper.rb
@@ -130,7 +130,7 @@ module Hopper
 
         registration.subscriber.send(registration.method, routing_key, message_data, source_object)
 
-        log(:info, "Sending #{routing_key} message to #{registration.method}")
+        log(:info, "Sending #{routing_key} message to #{registration.subscriber}:#{registration.method}")
       end
 
       log(:info, "Acknowledging #{delivery_tag}.")

--- a/lib/hopper.rb
+++ b/lib/hopper.rb
@@ -121,16 +121,25 @@ module Hopper
     end
 
     def handle_message(delivery_tag, routing_key, message)
+      log(:info, "Received message for routing key #{routing_key}.")
+
       message_data = JSON.parse(message, symbolize_names: true)
       source_object = LazySource.new(message_data[:source]) unless message_data[:source].nil?
       registrations.each do |registration|
         registration.subscriber.send(registration.method, routing_key, message_data, source_object) if registration.routing_key == routing_key
       end
+
+      log(:info, "Acknowledging #{delivery_tag}.")
+
       @channel.acknowledge(delivery_tag, false)
     rescue HopperRetriableError
+      log(:error, "Rejecting #{delivery_tag} due to retriable error")
+
       # it means it's a temporary error and the error needs to be re-sent
       @channel.reject(delivery_tag, true)
     rescue HopperNonRetriableError
+      log(:error, "Acknowledging #{delivery_tag} due to non-retriable error")
+
       # this means the message should not be delivered again
       # maybe added to a different queue for manual processing?
       @channel.acknowledge(delivery_tag, false)

--- a/lib/hopper.rb
+++ b/lib/hopper.rb
@@ -98,7 +98,10 @@ module Hopper
     private
 
     def initialize_hopper
-      connection = Bunny.new Hopper::Configuration.url
+      options = {
+        verify_peer: Hopper::Configuration.verify_peer
+      }
+      connection = Bunny.new Hopper::Configuration.url, options
       connection.start
       @channel = connection.create_channel
       @exchange = @channel.topic(Hopper::Configuration.exchange, durable: true)

--- a/lib/hopper/configuration.rb
+++ b/lib/hopper/configuration.rb
@@ -7,7 +7,8 @@ class Hopper::Configuration
     attr_accessor :configuration
 
     DEFAULTS = {
-      publish_retry_wait: 1.minute
+      publish_retry_wait: 1.minute,
+      verify_peer: false
     }.freeze
 
     def load(configuration)

--- a/lib/hopper/version.rb
+++ b/lib/hopper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hopper
-  VERSION = "0.3.2"
+  VERSION = "0.4.0"
 end

--- a/spec/hopper/configuration_spec.rb
+++ b/spec/hopper/configuration_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe Hopper::Configuration do
       expect(described_class.publish_retry_wait).to eq(2.minutes)
     end
 
+    it 'sets default verify_peer' do
+      described_class.load({})
+      expect(described_class.verify_peer).to eq(false)
+    end
+
+    it 'overrides default verify_peer' do
+      described_class.load(verify_peer: true)
+      expect(described_class.verify_peer).to eq(true)
+    end
+
     it 'raises NoMethodError for unknown configuration options' do
       expect { described_class.unknown_config }.to raise_error(NoMethodError)
     end

--- a/spec/hopper_spec.rb
+++ b/spec/hopper_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe Hopper do
       expect(connection).to be_open
     end
 
+    it 'sets the verify_peer option (default options)' do
+      described_class.init_channel(config)
+      expect(Bunny).to have_received(:new).with(config[:url], verify_peer: false)
+    end
+
+    it 'sets the verify_peer option' do
+      config[:verify_peer] = true
+      described_class.init_channel(config)
+      expect(Bunny).to have_received(:new).with(config[:url], verify_peer: true)
+    end
+
     it 'binds queue to registered routing keys' do
       described_class.subscribe(Object.new, :dummy_method, [routing_key1, routing_key2])
 


### PR DESCRIPTION
Progress on https://github.com/Zetatango/zetatango/issues/12205

Add support to verify the server endpoint certificate when connecting securely.