### PR TITLE
feat: Allow an uncaught exception handler to be set.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    hopper (0.4.0)
+    hopper (0.5.0)
       bunny (>= 2.13.0)
       rails
       rest-client

--- a/lib/hopper.rb
+++ b/lib/hopper.rb
@@ -102,9 +102,9 @@ module Hopper
         verify_peer: Hopper::Configuration.verify_peer
       }
       connection = Bunny.new Hopper::Configuration.url, options
-      connection.on_uncaught_exception(Hopper::Configuration.uncaught_exception_handler) if Hopper::Configuration.uncaught_exception_handler.present?
       connection.start
       @channel = connection.create_channel
+      @channel.on_uncaught_exception(&Hopper::Configuration.uncaught_exception_handler) if Hopper::Configuration.uncaught_exception_handler.present?
       @exchange = @channel.topic(Hopper::Configuration.exchange, durable: true)
       @queue = @channel.queue(Hopper::Configuration.queue, durable: true)
       bind_subscribers

--- a/lib/hopper.rb
+++ b/lib/hopper.rb
@@ -102,11 +102,7 @@ module Hopper
         verify_peer: Hopper::Configuration.verify_peer
       }
       connection = Bunny.new Hopper::Configuration.url, options
-
-      if Hopper::Configuration.uncaught_exception_handler.present?
-        connection.on_uncaught_exception(Hopper::Configuration.uncaught_exception_handler)
-      end
-
+      connection.on_uncaught_exception(Hopper::Configuration.uncaught_exception_handler) if Hopper::Configuration.uncaught_exception_handler.present?
       connection.start
       @channel = connection.create_channel
       @exchange = @channel.topic(Hopper::Configuration.exchange, durable: true)

--- a/lib/hopper.rb
+++ b/lib/hopper.rb
@@ -102,6 +102,11 @@ module Hopper
         verify_peer: Hopper::Configuration.verify_peer
       }
       connection = Bunny.new Hopper::Configuration.url, options
+
+      if Hopper::Configuration.uncaught_exception_handler.present?
+        connection.on_uncaught_exception(Hopper::Configuration.uncaught_exception_handler)
+      end
+
       connection.start
       @channel = connection.create_channel
       @exchange = @channel.topic(Hopper::Configuration.exchange, durable: true)

--- a/lib/hopper/configuration.rb
+++ b/lib/hopper/configuration.rb
@@ -8,7 +8,8 @@ class Hopper::Configuration
 
     DEFAULTS = {
       publish_retry_wait: 1.minute,
-      verify_peer: false
+      verify_peer: false,
+      uncaught_exception_handler: nil
     }.freeze
 
     def load(configuration)

--- a/lib/hopper/version.rb
+++ b/lib/hopper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hopper
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/hopper/configuration_spec.rb
+++ b/spec/hopper/configuration_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe Hopper::Configuration do
       expect(described_class.verify_peer).to eq(true)
     end
 
+    it 'sets the default uncaught_exception_handler to nil by default' do
+      expect(described_class.uncaught_exception_handler).to be_nil
+    end
+
+    it 'sets uncaught_exception_handler' do
+      handler = Proc.new {}
+      described_class.load(uncaught_exception_handler: handler)
+      expect(described_class.uncaught_exception_handler).to eq(handler)
+    end
+
     it 'raises NoMethodError for unknown configuration options' do
       expect { described_class.unknown_config }.to raise_error(NoMethodError)
     end

--- a/spec/hopper/configuration_spec.rb
+++ b/spec/hopper/configuration_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Hopper::Configuration do
     end
 
     it 'sets uncaught_exception_handler' do
-      handler = Proc.new {}
+      handler = proc {}
       described_class.load(uncaught_exception_handler: handler)
       expect(described_class.uncaught_exception_handler).to eq(handler)
     end

--- a/spec/hopper_spec.rb
+++ b/spec/hopper_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Hopper do
     end
 
     it 'sets the uncaught_exception_handler when set' do
-      handler = Proc.new { |_error, _component| nil }
+      handler = proc { |_error, _component| nil }
       config[:uncaught_exception_handler] = handler
 
       allow(connection).to receive(:on_uncaught_exception)

--- a/spec/hopper_spec.rb
+++ b/spec/hopper_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe Hopper do
       expect(Bunny).to have_received(:new).with(config[:url], verify_peer: true)
     end
 
+    it 'sets the uncaught_exception_handler when set' do
+      handler = Proc.new { |_error, _component| nil }
+      config[:uncaught_exception_handler] = handler
+
+      allow(connection).to receive(:on_uncaught_exception)
+
+      described_class.init_channel(config)
+
+      expect(connection).to have_received(:on_uncaught_exception).with(handler)
+    end
+
     it 'binds queue to registered routing keys' do
       described_class.subscribe(Object.new, :dummy_method, [routing_key1, routing_key2])
 


### PR DESCRIPTION
Hopper (Bunny) will log all uncaught exceptions by default but not raise them. This was causing exceptions in consumers to be swallowed and not properly logged.

With this change a default handler can now be set in the initializer code for Hopper so the application using Hopper can decide what to do with uncaught exceptions.