### PR TITLE
Hopper - add more debugging information

### DIFF
--- a/lib/hopper/configuration.rb
+++ b/lib/hopper/configuration.rb
@@ -9,7 +9,8 @@ class Hopper::Configuration
     DEFAULTS = {
       publish_retry_wait: 1.minute,
       verify_peer: false,
-      uncaught_exception_handler: nil
+      uncaught_exception_handler: nil,
+      consumer_tag: nil
     }.freeze
 
     def load(configuration)

--- a/lib/hopper/version.rb
+++ b/lib/hopper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hopper
-  VERSION = "0.5.0"
+  VERSION = "0.6.3"
 end

--- a/spec/hopper/configuration_spec.rb
+++ b/spec/hopper/configuration_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe Hopper::Configuration do
       expect(described_class.uncaught_exception_handler).to eq(handler)
     end
 
+    it 'sets consumer_tag to nil by default' do
+      described_class.load({})
+      expect(described_class.consumer_tag).to be_nil
+    end
+
+    it 'sets consumer_tag' do
+      described_class.load(consumer_tag: 'web1')
+      expect(described_class.consumer_tag).to eq('web1')
+    end
+
     it 'raises NoMethodError for unknown configuration options' do
       expect { described_class.unknown_config }.to raise_error(NoMethodError)
     end

--- a/spec/hopper_spec.rb
+++ b/spec/hopper_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe Hopper do
     let(:exchange) { channel.topic('test') }
     let(:message) { 'Hello' }
     let(:message_key) { 'message_key' }
+    let(:message_id) { SecureRandom.uuid }
 
     before do
       allow(Bunny).to receive(:new).and_return(bunny_server)
@@ -200,8 +201,9 @@ RSpec.describe Hopper do
       end
 
       it 'will publish the message on the channel' do
+        allow(SecureRandom).to receive(:uuid).and_return(message_id)
         described_class.publish(message, message_key)
-        expect(exchange).to have_received(:publish).with(message, routing_key: message_key, mandatory: true, persistent: true)
+        expect(exchange).to have_received(:publish).with(message, routing_key: message_key, mandatory: true, persistent: true, message_id: message_id)
       end
 
       it 'will not trigger the retry job if the publish succeeds' do


### PR DESCRIPTION
Issue:
https://github.com/Zetatango/zetatango/issues/12289

Why:
Seems that some of the messages get lost

How:
- added a message id to be able to link sent and received messages
- added more debugging messages
- added a consumer tag option, example of usage:
```
    config[:consumer_tag] = if Rails.env.production?
                              # leave nil if DYNO is not set
                              "#{ENV.fetch('DYNO')}-#{Time.now.to_i * 1000}-#{Kernel.rand(999_999_999_999)}" if ENV.fetch('DYNO').present?
                            else
                              "#{Process.pid}-#{Time.now.to_i * 1000}-#{Kernel.rand(999_999_999_999)}"
                            end
    Hopper.init_channel(config)
```

Reviewers:
@bcarr092 @DominicRoyStang 