### PR TITLE
Hopper - add log tag for handling message

### DIFF
--- a/lib/hopper/version.rb
+++ b/lib/hopper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hopper
-  VERSION = "0.6.3"
+  VERSION = "0.6.6"
 end

--- a/spec/hopper_spec.rb
+++ b/spec/hopper_spec.rb
@@ -40,13 +40,13 @@ RSpec.describe Hopper do
 
     it 'sets the verify_peer option (default options)' do
       described_class.init_channel(config)
-      expect(Bunny).to have_received(:new).with(config[:url], verify_peer: false)
+      expect(Bunny).to have_received(:new).with(config[:url], verify_peer: false, logger: Rails.logger)
     end
 
     it 'sets the verify_peer option' do
       config[:verify_peer] = true
       described_class.init_channel(config)
-      expect(Bunny).to have_received(:new).with(config[:url], verify_peer: true)
+      expect(Bunny).to have_received(:new).with(config[:url], verify_peer: true, logger: Rails.logger)
     end
 
     it 'binds queue to registered routing keys' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,9 +37,9 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  logger = Logger.new($stdout)
   config.before do
     logger = Logger.new($stdout)
+    allow(logger).to receive(:tagged).and_yield
     allow(Rails).to receive(:logger).and_return(logger)
   end
 end


### PR DESCRIPTION
Issue:
https://github.com/Zetatango/zetatango/issues/12289

Why:
Seems that some of the messages get lost

How:
- connected logger to bunny logger
- added message_id tag to logger (making it easier to track message handling)


Reviewers:
@bcarr092 @DominicRoyStang 