### PR TITLE
Use thread local variables to isolate threads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    hopper (0.6.16)
+    hopper (0.6.20)
       bunny (>= 2.13.0)
       rails
       rest-client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    hopper (0.6.7)
+    hopper (0.6.16)
       bunny (>= 2.13.0)
       rails
       rest-client
@@ -80,14 +80,14 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
-    amq-protocol (2.3.1)
+    amq-protocol (2.3.2)
     ast (2.4.1)
     bindata (2.4.8)
     builder (3.2.4)
     bundler-audit (0.7.0.1)
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
-    bunny (2.15.0)
+    bunny (2.17.0)
       amq-protocol (~> 2.3, >= 2.3.1)
     bunny-mock (1.7.0)
       bunny (>= 1.7)

--- a/lib/hopper.rb
+++ b/lib/hopper.rb
@@ -33,7 +33,7 @@ module Hopper
   INITIALIZED = "initialized"
 
   class << self
-    attr_reader :channel, :queue, :exchange, :state
+    attr_reader :state
 
     def init_channel(config)
       Hopper::Configuration.load(config)
@@ -67,8 +67,16 @@ module Hopper
 
       message = message.to_json if message.is_a? Hash
       options = message_options(key)
-      @exchange.publish(message.to_s, options)
-      log(:info, "Sent RabbitMQ message: key=#{key}, id=#{options[:message_id]}")
+      exchange.publish(message.to_s, options)
+
+      success = channel.wait_for_confirms
+
+      if success
+        log(:info, "Sent RabbitMQ message: key=#{key}, id=#{options[:message_id]}")
+      else
+        log(:error, "Confirmation not received for #{key}:#{message}. Retrying in #{Hopper::Configuration.publish_retry_wait}.")
+        Hopper::PublishRetryJob.set(wait: Hopper::Configuration.publish_retry_wait).perform_later(message, key)
+      end
     rescue Bunny::Exception => e
       log(:error, "Unable to publish message #{key}:#{message}. Retrying in #{Hopper::Configuration.publish_retry_wait}. Error: #{e.message}")
       Hopper::PublishRetryJob.set(wait: Hopper::Configuration.publish_retry_wait).perform_later(message, key)
@@ -77,13 +85,13 @@ module Hopper
     def subscribe(subscriber, method, routing_keys, opts = {})
       routing_keys.each do |routing_key|
         registration = RegistrationStruct.new(subscriber, method, routing_key, opts)
-        @queue.bind(@exchange, routing_key: routing_key) if @queue.present?
+        queue.bind(exchange, routing_key: routing_key)
         registrations << registration
       end
     end
 
     def start_listening
-      @queue.subscribe(manual_ack: true, block: false, consumer_tag: Hopper::Configuration.consumer_tag) do |delivery_info, properties, body|
+      queue.subscribe(manual_ack: true, block: false, consumer_tag: Hopper::Configuration.consumer_tag) do |delivery_info, properties, body|
         log(:info,
             "Received RabbitMQ message: key=#{delivery_info.routing_key}, id=#{properties[:message_id]}. tag=#{delivery_info.delivery_tag}")
         with_log_tagging(properties[:message_id]) do
@@ -100,20 +108,42 @@ module Hopper
       @semaphore ||= Mutex.new
     end
 
+    def connection
+      thread_local_variable(:hopper_connection) do
+        options = Hopper::Configuration.configuration
+        options[:logger] = Rails.logger if Rails.logger.present?
+
+        hopper_connection = Bunny.new Hopper::Configuration.url, options
+        hopper_connection.start
+      end
+    end
+
+    def queue
+      thread_local_variable(:hopper_queue) do
+        channel.queue(Hopper::Configuration.queue, durable: true)
+      end
+    end
+
+    def exchange
+      thread_local_variable(:hopper_exchange) do
+        channel.topic(Hopper::Configuration.exchange, durable: true)
+      end
+    end
+
+    def channel
+      thread_local_variable(:hopper_channel) do
+        channel = connection.create_channel
+        channel.on_uncaught_exception(&Hopper::Configuration.uncaught_exception_handler) if Hopper::Configuration.uncaught_exception_handler.present?
+        channel.confirm_select
+        channel
+      end
+    end
+
     private
 
     def initialize_hopper
-      options = {
-        verify_peer: Hopper::Configuration.verify_peer
-      }
-      options[:logger] = Rails.logger if Rails.logger.present?
-
-      connection = Bunny.new Hopper::Configuration.url, options
-      connection.start
-      @channel = connection.create_channel
-      @channel.on_uncaught_exception(&Hopper::Configuration.uncaught_exception_handler) if Hopper::Configuration.uncaught_exception_handler.present?
-      @exchange = @channel.topic(Hopper::Configuration.exchange, durable: true)
-      @queue = @channel.queue(Hopper::Configuration.queue, durable: true)
+      # initialize connection
+      connection
       bind_subscribers
       @state = INITIALIZED
     end
@@ -131,6 +161,7 @@ module Hopper
     def handle_message(delivery_tag, routing_key, message)
       message_data = JSON.parse(message, symbolize_names: true)
       source_object = LazySource.new(message_data[:source]) unless message_data[:source].nil?
+
       registrations.each do |registration|
         next unless registration.routing_key == routing_key
 
@@ -140,18 +171,18 @@ module Hopper
 
       log(:info, "Acknowledging #{delivery_tag}.")
 
-      @channel.acknowledge(delivery_tag, false)
+      channel.acknowledge(delivery_tag, false)
     rescue HopperRetriableError
       log(:warn, "Rejecting #{delivery_tag} due to retriable error")
 
       # it means it's a temporary error and the error needs to be re-sent
-      @channel.reject(delivery_tag, true)
+      channel.reject(delivery_tag, true)
     rescue HopperNonRetriableError
       log(:error, "Acknowledging #{delivery_tag} due to non-retriable error")
 
       # this means the message should not be delivered again
       # maybe added to a different queue for manual processing?
-      @channel.acknowledge(delivery_tag, false)
+      channel.acknowledge(delivery_tag, false)
     end
 
     def message_options(key)
@@ -166,7 +197,7 @@ module Hopper
     def bind_subscribers
       already_registered = Set.new
       registrations.each do |registration|
-        @queue.bind(@exchange, routing_key: registration.routing_key) unless already_registered.include?(registration.routing_key)
+        queue.bind(exchange, routing_key: registration.routing_key) unless already_registered.include?(registration.routing_key)
         already_registered << registration.routing_key
       end
     end
@@ -197,6 +228,16 @@ module Hopper
       Rails.logger.tagged(message_id) do
         yield block
       end
+    end
+
+    def thread_local_variable(var_name, &block)
+      result = Thread.current[var_name]
+      unless result.present?
+        result = yield block
+        Thread.current[var_name] = result
+      end
+
+      result
     end
   end
 end

--- a/lib/hopper/version.rb
+++ b/lib/hopper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hopper
-  VERSION = "0.6.16"
+  VERSION = "0.6.20"
 end

--- a/lib/hopper/version.rb
+++ b/lib/hopper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hopper
-  VERSION = "0.6.7"
+  VERSION = "0.6.16"
 end


### PR DESCRIPTION
Issue:
https://github.com/Zetatango/zetatango/issues/12653
Why:
Seems that some of the messages get lost

How:
Use thread local variables to keep separated the following: connection, queue, exchange and channel
Not the most elegant solution but I could not find a way to share the connection between multiple threads. 

Risks
- there is a potential for a lot of connections to be created `components * (puma workers * puma threads || resque workers)`
- not 100% sure how the connection closing is handled if puma recycles its workers, the daily restart should take care of any issues

Given the current status I think it's worth trying the current approach for a few days
I've tested in staging downloading multiple files at once and I got the downloads 100%

Reviewers:
@bcarr092 @DominicRoyStang

