### PR TITLE
Remove rapid rails registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  rubygems-server-gems-rapidrailsthemes-com-gems:
-    type: rubygems-server
-    url: https://gems.rapidrailsthemes.com/gems
-    username: "${{secrets.RUBYGEMS_SERVER_GEMS_RAPIDRAILSTHEMES_COM_GEMS_USERNAME}}"
-    password: "${{secrets.RUBYGEMS_SERVER_GEMS_RAPIDRAILSTHEMES_COM_GEMS_PASSWORD}}"
 
 updates:
 - package-ecosystem: bundler
@@ -40,5 +34,3 @@ updates:
     versions:
     - 0.9.2
     - 0.9.3
-  registries:
-  - rubygems-server-gems-rapidrailsthemes-com-gems


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/16789

*Why?*

Rapid rails registry no longer used 

*How?*

Remove registry link in config

*How did this defect occur?*

N/A

*Risks*

None.

*Requested Reviewers*

